### PR TITLE
Add support for caching generic types

### DIFF
--- a/fastapi_cache/backends/base.py
+++ b/fastapi_cache/backends/base.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Union
 
 DEFAULT_TIMEOUT = 600
 
@@ -7,7 +7,7 @@ class BaseCacheBackend(object):
     async def add(
         self,
         key: Union[str, int],
-        value: Union[str, int],
+        value: Any,
         timeout: int = DEFAULT_TIMEOUT
     ) -> bool:
         raise NotImplementedError
@@ -15,16 +15,16 @@ class BaseCacheBackend(object):
     async def get(
         self,
         key: Union[str, int],
-        default: Union[str, int] = None
-    ) -> bool:
+        default: Any = None
+    ) -> Any:
         raise NotImplementedError
 
     async def set(
         self,
         key: Union[str, int],
-        value: Union[str, int],
+        value: Any,
         timeout: int = DEFAULT_TIMEOUT
-    ) -> Union[str, int]:
+    ) -> bool:
         raise NotImplementedError
 
     async def delete(self, key: Union[str, int]) -> bool:

--- a/fastapi_cache/backends/memory.py
+++ b/fastapi_cache/backends/memory.py
@@ -1,6 +1,7 @@
-from typing import Union
+from typing import Any, Union
 
 from .base import BaseCacheBackend
+
 
 DEFAULT_TIMEOUT = 0
 CACHE_KEY = 'IN_MEMORY'
@@ -13,7 +14,7 @@ class InMemoryCacheBackend(BaseCacheBackend):
     async def add(
         self,
         key: Union[str, int],
-        value: Union[str, int],
+        value: Any,
         timeout: int = DEFAULT_TIMEOUT
     ) -> bool:
         if key in self._cache:
@@ -26,13 +27,13 @@ class InMemoryCacheBackend(BaseCacheBackend):
         self,
         key: Union[str, int],
         default: Union[str, int] = None
-    ) -> Union[str, int]:
+    ) -> Any:
         return self._cache.get(key, default)
 
     async def set(
         self,
         key: Union[str, int],
-        value: Union[str, int],
+        value: Any,
         timeout: int = DEFAULT_TIMEOUT
     ) -> bool:
         self._cache[key] = value

--- a/fastapi_cache/backends/redis.py
+++ b/fastapi_cache/backends/redis.py
@@ -1,9 +1,10 @@
-from typing import Union
+from typing import Any, Optional, Union
 
 import aioredis
 from aioredis import Redis
 
 from .base import BaseCacheBackend, DEFAULT_TIMEOUT
+
 
 DEFAULT_POOL_MIN_SIZE = 5
 CACHE_KEY = 'REDIS'
@@ -27,7 +28,7 @@ class RedisCacheBackend(BaseCacheBackend):
     async def add(
         self,
         key: Union[str, int],
-        value: Union[str, int],
+        value: Any,
         timeout: int = DEFAULT_TIMEOUT
     ) -> bool:
         """
@@ -55,17 +56,22 @@ class RedisCacheBackend(BaseCacheBackend):
     async def get(
         self,
         key: Union[str, int],
-        default: Union[str, int] = None
-    ) -> Union[str, int]:
+        default: Any = None,
+        encoding: Optional[str] = 'utf-8'
+    ) -> Any:
+        kwargs = {"key": key}
+        if encoding is not None:
+            kwargs['encoding'] = encoding
+
         client = await self._client
-        cached_value = await client.get(key, encoding='utf8')
+        cached_value = await client.get(**kwargs)
 
         return cached_value if cached_value is not None else default
 
     async def set(
         self,
         key: Union[str, int],
-        value: Union[str, int],
+        value: Any,
         timeout: int = DEFAULT_TIMEOUT
     ) -> bool:
         client = await self._client

--- a/fastapi_cache/version.py
+++ b/fastapi_cache/version.py
@@ -1,4 +1,4 @@
-VERSION = (0, 0, 4)
+VERSION = (0, 0, 5)
 
 __author__ = 'Ivan Sushkov <comeuplater>'
 __version__ = '.'.join(str(x) for x in VERSION)

--- a/tests/redis_tests.py
+++ b/tests/redis_tests.py
@@ -3,6 +3,7 @@ import pytest
 
 from fastapi_cache.backends.redis import RedisCacheBackend
 
+
 TEST_KEY = 'constant'
 TEST_VALUE = '0'
 
@@ -22,6 +23,18 @@ async def test_should_add_n_get_data(
 
     assert is_added is True
     assert await f_backend.get(TEST_KEY) == TEST_VALUE
+
+
+@pytest.mark.asyncio
+async def test_should_add_n_get_data_no_encoding(
+    f_backend: RedisCacheBackend
+) -> None:
+    NO_ENCODING_KEY = 'bytes'
+    NO_ENCODING_VALUE = b'test'
+    is_added = await f_backend.add(NO_ENCODING_KEY, NO_ENCODING_VALUE)
+
+    assert is_added is True
+    assert await f_backend.get(NO_ENCODING_KEY, encoding=None) == bytes(NO_ENCODING_VALUE)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix?

The current version of the package fails to retrieve  objects in Redis that cannot be decoded by the default `encoding='utf-8'` option defined on `get`. In order to enable a more generic approach this PR refactor the Cache classes changing the `value` typing (both when setting and when retrieving) to `Any`, minimizing IDE's warnings, and adds a new optional parameter `encoding` to `RedisCacheBackend.get` method, keeping `utf-8` as the default value to enable backwards compatibility. A new simple test for the option `encoding=None` was added.