### PR TITLE
Create expire function

### DIFF
--- a/fastapi_cache/backends/redis.py
+++ b/fastapi_cache/backends/redis.py
@@ -99,6 +99,15 @@ class RedisCacheBackend(BaseCacheBackend[RedisAcceptable, Any]):
         client = await self._client
         await client.flushdb()
 
+    async def expire(
+        self,
+        key: RedisAcceptable,
+        value: Any
+    ) -> bool:
+        client = await self._client
+
+        return await client.expire(key, value)
+
     async def close(self) -> None:
         client = await self._client
         client.close()

--- a/tests/redis_tests.py
+++ b/tests/redis_tests.py
@@ -2,6 +2,7 @@ from typing import Tuple, List
 
 import aioredis
 import pytest
+import asyncio
 
 from fastapi_cache.backends.redis import RedisCacheBackend
 
@@ -127,6 +128,17 @@ async def test_delete_should_remove_from_cache(
 
     assert fetched_value is None
 
+
+@pytest.mark.asyncio
+async def test_expire_from_cache(
+    f_backend: RedisCacheBackend
+) -> None:
+    await f_backend.add(TEST_KEY, TEST_VALUE)
+    await f_backend.expire(TEST_KEY, 1)
+    await asyncio.sleep(3)
+    fetched_value = await f_backend.get(TEST_KEY)
+
+    assert fetched_value is None
 
 @pytest.mark.asyncio
 async def test_flush_should_remove_all_objects_from_cache(

--- a/tests/redis_tests.py
+++ b/tests/redis_tests.py
@@ -141,6 +141,17 @@ async def test_expire_from_cache(
     assert fetched_value is None
 
 @pytest.mark.asyncio
+async def test_expire_from_cache_failure(
+    f_backend: RedisCacheBackend
+) -> None:
+    await f_backend.add(TEST_KEY, TEST_VALUE)
+    await f_backend.expire(TEST_KEY, 5)
+    await asyncio.sleep(3)
+    fetched_value = await f_backend.get(TEST_KEY)
+
+    assert fetched_value is TEST_VALUE
+
+@pytest.mark.asyncio
 async def test_flush_should_remove_all_objects_from_cache(
     f_backend: RedisCacheBackend
 ) -> None:


### PR DESCRIPTION
This PR will include the aioredis function for expire(key, timeout) in order to automatically invalidate an entry after some time. This is useful when using redis for caching API responses.