### PR TITLE
Upgrade aioredis to 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         'redis', 'aioredis', 'asyncio', 'fastapi', 'starlette', 'cache'
     ],
     install_requires=[
-        'aioredis==1.3.1',
+        'aioredis==2.0.0',
     ],
 )

--- a/tests/redis_tests.py
+++ b/tests/redis_tests.py
@@ -166,8 +166,8 @@ async def test_close_should_close_connection(
     f_backend: RedisCacheBackend
 ) -> None:
     await f_backend.close()
-    with pytest.raises(aioredis.errors.PoolClosedError):
-        await f_backend.add(TEST_KEY, TEST_VALUE)
+    assert len(f_backend._pool.connection_pool._available_connections) == 0
+    assert len(f_backend._pool.connection_pool._in_use_connections) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/redis_tests.py
+++ b/tests/redis_tests.py
@@ -32,6 +32,7 @@ async def test_should_add_n_get_data_no_encoding(
 ) -> None:
     NO_ENCODING_KEY = 'bytes'
     NO_ENCODING_VALUE = b'test'
+    await f_backend.expire(NO_ENCODING_KEY, 0)
     is_added = await f_backend.add(NO_ENCODING_KEY, NO_ENCODING_VALUE)
 
     assert is_added is True


### PR DESCRIPTION
aioredis 2.x introduces breaking changes in API

- `poo_min_size` is dropped, the connection pool is now lazy filled, not pre-filled
- whether decode or not is decided globally, could not be changed on each top level api (like `Redis.get()`)