### PR TITLE
chore: Fix pytest unknown marker warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 python_files = tests.py test_*.py *_tests.py *_test.py
 addopts = --doctest-modules
+markers =
+  backwards: Run the tests for backward compatible support


### PR DESCRIPTION
Declare custom markers in `pytest.ini` to avoid unknown marker warning.